### PR TITLE
feat: add automatic .env file loading support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Create non-root user
 RUN addgroup -S spring && adduser -S spring -G spring
 
-# Copy the pre-built JAR
-COPY build/libs/*.jar app.jar
+# Copy the pre-built executable Spring Boot JAR
+COPY build/libs/crazy-counter-0.0.1-SNAPSHOT.jar app.jar
 
 # Change ownership
 RUN chown spring:spring app.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,17 +22,20 @@ repositories {
 dependencies {
     // Spring Boot
     implementation(libs.bundles.spring.boot)
-    
+
     // Kotlin
     implementation(libs.bundles.kotlin)
-    
+
     // Discord
     implementation(libs.jda)
-    
+
+    // Configuration
+    implementation(libs.dotenv.kotlin)
+
     // Database
     runtimeOnly(libs.h2)
     runtimeOnly(libs.mysql)
-    
+
     // Testing
     testImplementation(libs.bundles.testing)
     testImplementation(libs.spring.boot.starter.test) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,9 @@ jackson-kotlin = "2.17.2"
 testng = "7.9.0"
 mockito-kotlin = "5.4.0"
 
+# Configuration
+dotenv-kotlin = "6.4.1"
+
 # Java Target (Kotlin 2.2.x supports up to JVM target 24)
 java = "24"
 
@@ -41,6 +44,9 @@ mysql = { module = "com.mysql:mysql-connector-j", version.ref = "mysql" }
 # Testing
 testng = { module = "org.testng:testng", version.ref = "testng" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
+
+# Configuration
+dotenv-kotlin = { module = "io.github.cdimascio:dotenv-kotlin", version.ref = "dotenv-kotlin" }
 
 [bundles]
 spring-boot = ["spring-boot-starter", "spring-boot-starter-data-jpa"]

--- a/src/main/kotlin/com/example/crazycounter/config/DotenvConfig.kt
+++ b/src/main/kotlin/com/example/crazycounter/config/DotenvConfig.kt
@@ -1,0 +1,38 @@
+package com.example.crazycounter.config
+
+import io.github.cdimascio.dotenv.Dotenv
+import io.github.cdimascio.dotenv.DotenvException
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.MapPropertySource
+
+/**
+ * Loads environment variables from .env file before Spring Boot context initialization.
+ * This allows .env values to be available for @Value and ${...} property resolution.
+ */
+class DotenvConfig : ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private val logger = LoggerFactory.getLogger(DotenvConfig::class.java)
+
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        try {
+            val dotenv = Dotenv.configure()
+                .ignoreIfMissing()  // Don't fail if .env doesn't exist (e.g., in production)
+                .load()
+
+            val dotenvProperties = dotenv.entries()
+                .associate { it.key to it.value }
+
+            if (dotenvProperties.isNotEmpty()) {
+                logger.info("Loaded ${dotenvProperties.size} variables from .env file")
+                val propertySource = MapPropertySource("dotenvProperties", dotenvProperties)
+                applicationContext.environment.propertySources.addFirst(propertySource)
+            } else {
+                logger.debug("No .env file found or file is empty")
+            }
+        } catch (e: DotenvException) {
+            logger.warn("Could not load .env file: ${e.message}")
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.context.ApplicationContextInitializer=\
+com.example.crazycounter.config.DotenvConfig


### PR DESCRIPTION
## Summary

This PR adds automatic `.env` file loading support for local development, eliminating the need to manually export environment variables before running the application.

### Changes Made

- **Added dotenv-kotlin dependency** (v6.4.1) via Gradle version catalog
- **Created `DotenvConfig` initializer** that loads `.env` files before Spring Boot context initialization
- **Registered initializer** via `spring.factories` for automatic Spring Boot discovery
- **Updated Dockerfile** to use explicit JAR filename instead of wildcard pattern

### Problem Solved

Previously, the Discord bot would fail to start locally because Spring Boot doesn't automatically read `.env` files. Users had to:
- Manually export environment variables (`export DISCORD_BOT_TOKEN=...`)
- Or configure their IDE to inject environment variables
- Or modify `application.yml` directly (not ideal)

### Benefits

✅ **Developer-friendly**: Just create a `.env` file and run `./gradlew bootRun`
✅ **Production-safe**: Gracefully handles missing `.env` files, falls back to system environment variables
✅ **Docker-compatible**: Docker Compose already reads `.env` automatically
✅ **Version-controlled**: Uses Gradle version catalog for dependency management
✅ **Explicit Docker builds**: Dockerfile now uses exact JAR name for predictability

### Testing

Tested both local and Docker deployments:

**Local (H2 database):**
```bash
./gradlew bootRun
# ✅ Loaded 60 variables from .env file
# ✅ Discord bot is ready! Connected as: Crazy Counter
```

**Docker (MySQL database):**
```bash
docker-compose up --build
# ✅ Login Successful!
# ✅ Connected to MySQL database
# ✅ Startup notification sent to Discord
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
